### PR TITLE
fix: set marketing mail nullable

### DIFF
--- a/src/shop/shop.entity.ts
+++ b/src/shop/shop.entity.ts
@@ -40,7 +40,7 @@ export class Shop {
   @Column()
   email: string;
 
-  @Column()
+  @Column({ nullable: true })
   marketingEmail: string;
 
   @Column({


### PR DESCRIPTION
# Error
build failed on Scalingo with this log : 
```
 ERROR [ExceptionHandler] column "marketing email" of relation "shop" contains null values
```
# fix
fix the Scalingo build by making the marketing email nullable 

this will be a temporary fix

